### PR TITLE
[FIX] storage_backend_ftp: fix list and get

### DIFF
--- a/storage_backend_ftp/readme/CONTRIBUTORS.rst
+++ b/storage_backend_ftp/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * François Honoré <francois.honore@acsone.eu>
+* Lois Rilo <lois.rilo@forgeflow.com>


### PR DESCRIPTION
* list should return a python list of files.
* get should get and directly return the bynary from the FTP.
  Before, a string was being retrived and then encoded. This is
  problematic if the original binary was not utf-8.